### PR TITLE
Define the .well-known response as JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,8 +281,8 @@
         </p>
         <p>
           The GPC support representation MUST be an
-          <a href="https://infra.spec.whatwg.org/#ordered-map">ordered map</a>.
-          The unordered map MUST have a the following members (all other values MUST be ignored):
+          <a href="https://tools.ietf.org/html/rfc8259#section-4">JSON object</a>.
+          The JSON object MUST have a the following members (all other values MUST be ignored):
           <ul>
             <li>
               A <code>gpc</code> member. The value of the <code>gpc</code> member MUST be either


### PR DESCRIPTION
change the definition of the returned text from an ordered map to a JSON object, to both have something thats implementable in JSON and maximally compatible 