### PR TITLE
Add acknowledgments section to properly credit TPWG and others who contributed to DNT

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,5 +409,12 @@
         interacting with that preference already active.
       </p>
     </section>
+    <section class="appendix">
+      <h2>Acknowledgments</h2>
+        This specification relies on concepts developed in large part by the
+        <a href="https://www.w3.org/2011/tracking-protection/">Tracking Protection Working Group</a>
+        and others who contributed to
+        <a href="https://www.w3.org/TR/tracking-dnt/">Tracking Preference Expression (DNT)</a>.
+    </section>
   </body>
 </html>


### PR DESCRIPTION
It was an oversight to not include this section from the start.