### PR TITLE
Ensure consistency between HTTP and JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,6 +197,24 @@
         </p>
       </section>
       <section>
+        <h3>Preference Caching</h3>
+        <p>
+          The [=preference=] must be cached on every top-level navigation to ensure consistency in communication of
+          the person's request that their data "not be sold or shared." This means that if the [=preference=] changes
+          during or after a top-level navigation, it will not be reflected until the next navigation.
+        </p>
+        <p>
+          A [=top-level browsing context=] has a <dfn><code>cachedGPCAtTimeOfLastNavigation</code></dfn> boolean.
+          It is initially <code>false</code>.
+        </p>
+        <p>
+          When [=process a navigate fetch=] is run with [=top-level browsing context=] as <code>browsingContext</code>,
+          [=top-level browsing context=]'s <dfn><code>cachedGPCAtTimeOfLastNavigation</code></dfn> is updated to
+          <code>true</code> if the [=preference=] is enabled, and <code>false</code> if the the [=preference=] is disabled
+          or defaulted to.
+        </p>
+      </section>
+      <section>
         <h3>The <code>Sec-GPC</code> Header Field for HTTP Requests</h3>
         <p>
           The <dfn><code>Sec-GPC</code></dfn> header field is a mechanism for expressing the person's
@@ -211,13 +229,13 @@
           Sec-GPC-field-value = "1"
         </pre>
         <p>
-          A user agent MUST NOT generate a <code>[=Sec-GPC=]</code> header field if the person's Global
-          Privacy Control [=preference=] is not enabled or defaulted to.
+          A user agent MUST NOT generate a <code>[=Sec-GPC=]</code> header field if [=top-level browsing context=]'s
+          <code>cachedGPCAtTimeOfLastNavigation</code> is <code>false</code>.
         </p>
         <p>
           A user agent MUST generate a <code>[=Sec-GPC=]</code> header field with a field-value that
-          is exactly the numeric character "1" if the person's Global Privacy Control [=preference=]
-          is set.
+          is exactly the numeric character "1" if [=top-level browsing context=]'s
+          <code>cachedGPCAtTimeOfLastNavigation</code> is <code>true</code>.
         </p>
         <p>
           A user agent MUST NOT generate more than one <code>[=Sec-GPC=]</code> in a given HTTP
@@ -264,8 +282,7 @@
         <h2>JavaScript Property to Detect Preference</h2>
         <p>
           The {{GlobalPrivacyControl/globalPrivacyControl}} property enables a client-side
-          script to determine what <code>[=Sec-GPC=]</code> header field value was sent when
-          loading the [=top-level browsing context=]'s [=active document=].
+          script to determine what <code>[=Sec-GPC=]</code> header field value was sent.
         </p>
         <pre class="idl">
           interface mixin GlobalPrivacyControl {
@@ -275,17 +292,12 @@
           WorkerNavigator includes GlobalPrivacyControl;
         </pre>
         <p>
-          The value is <code>false</code> if no <code>Sec-GPC</code> header field would be sent;
+          The value is <code>false</code> if no <code>Sec-GPC</code> header field was be sent;
           otherwise, the value is <code>true</code>.
         </p>
         <p>
-          Specifically, the value of {{GlobalPrivacyControl/globalPrivacyControl}} for a given script is
-          <code>true</code> if a person has requested that their data "not be sold or shared" via
-          setting a Global Privacy Control [=preference=].
-        </p>
-        <p>
-          The value of {{GlobalPrivacyControl/globalPrivacyControl}} MUST reflect the [=preference=]
-          of the person when the [=top-level browsing context=]'s [=active document=] began loading.
+          Specifically, the value of {{GlobalPrivacyControl/globalPrivacyControl}} MUST reflect
+          [=top-level browsing context=]'s <code>cachedGPCAtTimeOfLastNavigation</code>.
         </p>
         <p>
           The {{GlobalPrivacyControl/globalPrivacyControl}} property is available on the


### PR DESCRIPTION
As written, the current spec implies that:
- HTTP headers always reflect the current GPC preference
- JavaScript properties always reflect the preference when the top-level browsing context started loading

This is inconsistent, and seems like it will lead to weird edge cases if the preference is changed mid-load. I propose that we adopt the approach of JavaScript for HTTP so both return the preference cached at the time of the last top-level navigation.