### PR TITLE
Resolving ReSpec errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
         <p>
           The {{GlobalPrivacyControl/globalPrivacyControl}} property enables a client-side
           script to determine what <code>[=Sec-GPC=]</code> header field value was sent when
-          loading the [=top-level browsing context=]'s [=active document=].
+          loading the [=top-level browsing context=]'s [=navigable/active document=].
         </p>
         <pre class="idl">
           interface mixin GlobalPrivacyControl {
@@ -285,7 +285,7 @@
         </p>
         <p>
           The value of {{GlobalPrivacyControl/globalPrivacyControl}} MUST reflect the [=preference=]
-          of the person when the [=top-level browsing context=]'s [=active document=] began loading.
+          of the person when the [=top-level browsing context=]'s [=navigable/active document=] began loading.
         </p>
         <p>
           The {{GlobalPrivacyControl/globalPrivacyControl}} property is available on the


### PR DESCRIPTION
Resolving ReSpec errors that are thrown when rendering the website - `https://globalprivacycontrol.github.io/gpc-spec/`

-----

```
Couldn't find "active document" in this document or other cited documents: [html] and [webidl].

How to fix: [See search matches for "active document"](https://respec.org/xref/?term=active+document&types=_CONCEPT_) or [Learn about this error](https://respec.org/docs/#error-term-not-found).

Occurred 2 times at:

    [<a>](https://globalprivacycontrol.github.io/gpc-spec/#respec-offender-no-matching-definition-found) element
    [<a>](https://globalprivacycontrol.github.io/gpc-spec/#respec-offender-no-matching-definition-found-0) element
```